### PR TITLE
Use RPi API for determining default i2c bus

### DIFF
--- a/simbamon/mopiapi.py
+++ b/simbamon/mopiapi.py
@@ -7,7 +7,6 @@ import errno
 import re
 import RPi.GPIO
 
-
 # Version of the API
 APIVERSION=0.3
 


### PR DESCRIPTION
RPi.GPIO provides the board revision, which determines the i2c bus to guess - so use that instead of the file based equivalent currently being used.
