### PR TITLE
Use correct variable for scope in i2c i/o errors

### DIFF
--- a/simbamon/mopiapi.py
+++ b/simbamon/mopiapi.py
@@ -113,9 +113,9 @@ class mopiapi():
 			tries += 1
 		# unsucessfully read
 		if error != 0:
-			if e.errno == errno.EIO:
-				e.strerror = "I2C bus input/output error on read config"
-			raise e
+			if error.errno == errno.EIO:
+				error.strerror = "I2C bus input/output error on read config"
+			raise error
 		if tries == MAXTRIES or (self.maj == 3 and self.minr > 9 and data[0] == 255):
 			raise IOError(errno.ECOMM, "Communications protocol error on read config")
 		# behaivour changed at v3.10 to 5x0 so that 255 could serve as error detection
@@ -169,9 +169,9 @@ class mopiapi():
 			tries += 1
 		# unsucessfully written
 		if error != 0:
-			if e.errno == errno.EIO:
-				e.strerror = "I2C bus input/output error on send config"
-			raise e
+			if error.errno == errno.EIO:
+				error.strerror = "I2C bus input/output error on send config"
+			raise error
 		if tries == MAXTRIES:
 			raise IOError(errno.ECOMM, "Communications protocol error on send config")
 
@@ -208,9 +208,9 @@ class mopiapi():
 			tries += 1
 		# unsucessfully read
 		if error != 0:
-			if e.errno == errno.EIO:
-				e.strerror = "I2C bus input/output error on read word"
-			raise e
+			if error.errno == errno.EIO:
+				error.strerror = "I2C bus input/output error on read word"
+			raise error
 		if data == 0xFFFF:
 			raise IOError(errno.ECOMM, "Communications protocol error on read word")
 		return data
@@ -260,9 +260,9 @@ class mopiapi():
 			tries += 1
 		# unsucessfully written
 		if error != 0:
-			if e.errno == errno.EIO:
-				e.strerror = "I2C bus input/output error on write word"
-			raise e
+			if error.errno == errno.EIO:
+				error.strerror = "I2C bus input/output error on write word"
+			raise error
 		if tries == MAXTRIES:
 			raise IOError(errno.ECOMM, "Communications protocol error on write word")
 			


### PR DESCRIPTION
The i2c i/o error code currently tried to use `e` which only exists in the scope of the earlier `except` block. The correct scope variable is `error` which `e` is assigned out to.

The existing code will yield UnboundLocalError "local variable 'e' referenced before assignment" instead of passing the original error.